### PR TITLE
Fix MongoDatabase>>collections

### DIFF
--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/collections.st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/collections.st
@@ -1,10 +1,10 @@
 operations
 collections
-	| query reply names real stripped |
-	query := MongoQuery new collection: (MongoMetaCollection name: 'system.namespaces').
-	reply := self query: query.
-	"Drop options on the floor for now"
-	names := reply collect: [:each | each at: 'name'].
-	real := names select: [:each | (each occurrencesOf: $.) = 1].
-	stripped := real collect: [:each | each readStream upTo: $.; upToEnd].
-	^stripped collect: [:each | MongoCollection database: self name: each]
+	"Answer the collections in this database"
+
+	| collectionNames |
+	collectionNames := root majorVersion < 3
+		ifTrue: [ self mongo2CollectionNames ]
+		ifFalse: [ self mongo3CollectionNames ].
+	^ collectionNames
+		collect: [:each | MongoCollection database: self name: each ]

--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/mongo2CollectionNames.st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/mongo2CollectionNames.st
@@ -1,0 +1,13 @@
+operations
+mongo2CollectionNames
+	"Answer the names of the collections in this database (for MongoDB < 3.0). 
+	Before 3.0, it is possible to obtain this information via a query to <database>.system.namespaces.
+	This has been deprecated since MongoDB 3.0, then such query returns an empty collection. See more at: https://docs.mongodb.com/manual/reference/system-collections/#%3Cdatabase%3E.system.namespaces"
+
+	| query reply names real |
+	query := MongoQuery new collection: (MongoMetaCollection name: 'system.namespaces').
+	reply := self query: query.
+	"Drop options on the floor for now"
+	names := reply collect: [ :each | each at: 'name' ].
+	real := names select: [ :each | (each occurrencesOf: $.) = 1 ].
+	^real collect: [:each | each readStream upTo: $.; upToEnd ]

--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/mongo3CollectionNames.st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/mongo3CollectionNames.st
@@ -1,0 +1,9 @@
+operations
+mongo3CollectionNames
+	"Answer the names of the collections in this database (for MongoDB >= 3.0).
+
+	See more at https://docs.mongodb.com/manual/reference/command/listCollections/"
+
+	| reply |
+	reply := self command: {(#listCollections -> 1)} asDictionary.
+	^ ((reply at: 'cursor') at: 'firstBatch') collect: [ :each | each at: 'name' ]


### PR DESCRIPTION
MongoDB 3.0 changed the way to get the list of a database's collections, as explained by Udo Schneider (@krodelin) in #12 .

Changes in MongoDatabase:

```
collections
	"Answer the collections in this database"

	| collectionNames |
	collectionNames := root majorVersion < 3
		ifTrue: [ self mongo2CollectionNames ]
		ifFalse: [ self mongo3CollectionNames ].
	^ collectionNames
		collect: [:each | MongoCollection database: self name: each ]
```

The old implementation of #collections is now named like this:
```
mongo2CollectionNames
	"Answer the names of the collections in this database (for MongoDB < 3.0). 
	Before 3.0, it is possible to obtain this information via a query to <database>.system.namespaces.
	This has been deprecated since MongoDB 3.0, then such query returns an empty collection. See more at: https://docs.mongodb.com/manual/reference/system-collections/#%3Cdatabase%3E.system.namespaces"

	| query reply names real |
	query := MongoQuery new collection: (MongoMetaCollection name: 'system.namespaces').
	reply := self query: query.
	"Drop options on the floor for now"
	names := reply collect: [ :each | each at: 'name' ].
	real := names select: [ :each | (each occurrencesOf: $.) = 1 ].
	^real collect: [:each | each readStream upTo: $.; upToEnd ]
```

and the new implementation to get collection names is:

```
mongo3CollectionNames
	"Answer the names of the collections in this database (for MongoDB >= 3.0).
	See more at https://docs.mongodb.com/manual/reference/command/listCollections/"

	| reply |
	reply := self command: {(#listCollections -> 1)} asDictionary.
	^ ((reply at: 'cursor') at: 'firstBatch') collect: [ :each | each at: 'name' ]
```
In fact, this implementation for 3.0 is buggy because it answers only a "first batch" of collections. However, I propose this fix as a workaround to have green tests, and after we can provide a better fix in another PR.