### PR TITLE
removed pharo4 from travis builds as we do not actively support that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
 smalltalk:
   - Pharo-6.0
   - Pharo-5.0
-  - Pharo-4.0
 
 env:
   - MONGODB=2.6


### PR DESCRIPTION
anymore