### PR TITLE
Disable the nagle algorithm for the mongo connection

### DIFF
--- a/mc/Mongo-Core.package/Mongo.class/instance/open.st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/open.st
@@ -1,4 +1,5 @@
 operations
 open
 	stream := GratuitousIncompatibilities socketStreamHost: host port: port.
+	stream socket setOption: 'TCP_NODELAY' value: 1.
 	authCache := nil

--- a/mc/Mongo-Core.package/monticello.meta/categories.st
+++ b/mc/Mongo-Core.package/monticello.meta/categories.st
@@ -1,8 +1,8 @@
 SystemOrganization addCategory: #'Mongo-Core'!
-SystemOrganization addCategory: 'Mongo-Core-Auth'!
-SystemOrganization addCategory: 'Mongo-Core-Base'!
-SystemOrganization addCategory: 'Mongo-Core-Collections'!
-SystemOrganization addCategory: 'Mongo-Core-Errors'!
-SystemOrganization addCategory: 'Mongo-Core-Operations'!
-SystemOrganization addCategory: 'Mongo-Core-Replication'!
-SystemOrganization addCategory: 'Mongo-Core-Utilities'!
+SystemOrganization addCategory: #'Mongo-Core-Auth'!
+SystemOrganization addCategory: #'Mongo-Core-Base'!
+SystemOrganization addCategory: #'Mongo-Core-Collections'!
+SystemOrganization addCategory: #'Mongo-Core-Errors'!
+SystemOrganization addCategory: #'Mongo-Core-Operations'!
+SystemOrganization addCategory: #'Mongo-Core-Replication'!
+SystemOrganization addCategory: #'Mongo-Core-Utilities'!


### PR DESCRIPTION
If delayed TCPs are enabled and  issueing:

   insert
  getLastError

There will be a 40ms (default delayed ack delay) between sending insert and getLastError. This will reduce per Smalltalk process throughput. Assume this is a StreamSocket and disable nagle. It should work with Squeak and Pharo.