### PR TITLE
Update in Replica Set tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ install:
 
 before_script:
   - "mongo test --eval 'db.createUser({ \"user\": \"pharounittest\", \"pwd\": \"test\", roles: [] });'"
+	- export baseRepositoryPath=$SMALLTALK_CI_BUILD/replicatest/
+	- export replicaSetName=db
+  - ./scripts/rs-setup.sh
 
 # bob-bench xUnit file analysis
 after_success:

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/defaultTimeLimit.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/defaultTimeLimit.st
@@ -1,0 +1,3 @@
+running
+defaultTimeLimit
+	^ 40 seconds

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/newMongo.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/newMongo.st
@@ -1,4 +1,3 @@
 instance creation
 newMongo
-
-	^Mongo host: 'localhost' port: 27031
+	^ Mongo host: 'localhost' port: 27031

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetConfig.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetConfig.st
@@ -1,10 +1,6 @@
 tests
 testReplicaSetConfig
 	| replicaSet |
-
-	"See _manual_set_up_ to set up the testing mongodb replica set."
-	isMongoAvailable ifFalse: [ ^self skip ].
-
 	replicaSet := mongo replicaSetConfig.
 
 	self assert: replicaSet name isString.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStatus.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStatus.st
@@ -1,10 +1,6 @@
 tests
 testReplicaSetStatus
 	| replicaSetStatus |
-
-	"See _manual_set_up_ to set up the testing mongodb replica set."
-	isMongoAvailable ifFalse: [ ^self skip ].
-
 	replicaSetStatus := mongo replicaSetStatus.
 
 	self assert: replicaSetStatus name isString.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStepDown.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStepDown.st
@@ -1,16 +1,23 @@
 tests
 testReplicaSetStepDown
 
+	"Step down the (prioritary) primary during some seconds"
 	mongo replicaSetStepDown: 10 seconds.
 
+	"It's still connected but it's not primary."
 	self assert: mongo isOpen.
 	
+	"Then, it will signal an error on a write operation."
 	[ 	self addNewCollection.
 		self fail: 'should raise a `not master` error' ]
 			on: MongoCommandError
 			do: [ :error | 
 				self assert: error isNotMaster ].
-			
-	20 seconds wait.
+
+	"When the step down seconds passed, and the election finished, 
+	the former primary server will be the primary again because it has more priority
+	(see the replication scenario)."
+	30 seconds wait.
 	
-	self addNewCollection. "It should be primary again"
+	"It should be primary again, and complete the write operation without any error."
+	self shouldnt: [ self addNewCollection ] raise: MongoCommandError.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStepDown.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testReplicaSetStepDown.st
@@ -1,9 +1,6 @@
 tests
 testReplicaSetStepDown
 
-	"See _manual_set_up_ to set up the testing mongodb replica set."
-	isMongoAvailable ifFalse: [ ^self skip ].
-
 	mongo replicaSetStepDown: 10 seconds.
 
 	self assert: mongo isOpen.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationTest.class/instance/setUp.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationTest.class/instance/setUp.st
@@ -2,7 +2,5 @@ running
 setUp
 	super setUp.
 	
-	isMongoAvailable :=
-		[ mongo := self newMongo. mongo open. true ] 
-			on: NetworkError 
-			do: [ 	false ].
+	mongo := self newMongo.
+	mongo open.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationTest.class/properties.json
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationTest.class/properties.json
@@ -6,8 +6,7 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"mongo",
-		"isMongoAvailable"
+		"mongo"
 	],
 	"name" : "MongoReplicationTest",
 	"type" : "normal"

--- a/mc/Mongo-Tests-Core.package/MongoReplicationTestResources.class/instance/_manual_set_up_.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationTestResources.class/instance/_manual_set_up_.st
@@ -37,6 +37,6 @@ _manual_set_up_
 
 	3. Next times:
 	
-		<MONGOTALK_GIT_DIRECTORY>/scripts/rs-serve.sh  
+		<MONGOTALK_GIT_DIRECTORY>/scripts/rs-serve.sh
 	
 	"

--- a/scripts/rs-createDbDirectories.sh
+++ b/scripts/rs-createDbDirectories.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-set -e
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/rs-checkEnvirnomentVariables.sh
+set -ex
+source $(dirname $0)/rs-checkEnvirnomentVariables.sh
 
-
-# only first time: create db dirs
+# create each db directory if it doesn't exist
 for i in `seq 1 3`;
 do
-	mkdir $baseRepositoryPath$replicaSetName$i
+	mkdir -p $baseRepositoryPath$replicaSetName$i
 done
-

--- a/scripts/rs-initiateRS.sh
+++ b/scripts/rs-initiateRS.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-set -e
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/rs-checkEnvirnomentVariables.sh
+set -ex
+source $(dirname $0)/rs-checkEnvirnomentVariables.sh
 
 # wait mongos are ready
 for i in `seq 1 3`;
@@ -18,5 +17,5 @@ mongo --port 27031 --eval 'rs.add("localhost:27032")'
 mongo --port 27031 --eval 'rs.add("localhost:27033")'
 
 # reconfigure with descending priorities (5, 3, 0)
-mongo --port 27031 --eval 'rs.reconfig({ "_id" : '\"${replicaSetName}\"', "members" : [ { "_id" : 1, "host" : "localhost:27031", "priority" : 5.0, }, { "_id" : 2, "host" : "localhost:27032", "priority" : 3.0, }, { "_id" : 3, "host" : "localhost:27033", "priority" : 0.0, } ], }, {force: true})'
+mongo --port 27031 --eval 'rs.reconfig({ "_id" : '\"${replicaSetName}\"', "protocolVersion" : 1, "members" : [ { "_id" : 1, "host" : "localhost:27031", "priority" : 5.0, }, { "_id" : 2, "host" : "localhost:27032", "priority" : 3.0, }, { "_id" : 3, "host" : "localhost:27033", "priority" : 0.0, } ] }, {force: true})'
 

--- a/scripts/rs-serve.sh
+++ b/scripts/rs-serve.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-set -e
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/rs-checkEnvirnomentVariables.sh
+set -ex
+source $(dirname $0)/rs-checkEnvirnomentVariables.sh
 
 scenarioMongoNames=(ZERO A B C)
 

--- a/scripts/rs-setup.sh
+++ b/scripts/rs-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-$DIR/rs-createDbDirectories.sh
-$DIR/rs-serve.sh
-$DIR/rs-initiateRS.sh
+source $(dirname $0)/rs-createDbDirectories.sh
+source $(dirname $0)/rs-serve.sh
+source $(dirname $0)/rs-initiateRS.sh

--- a/scripts/rs-stopAll.sh
+++ b/scripts/rs-stopAll.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 for i in `seq 1 3`;
 do
 	echo stop mongo at port 2703$i


### PR DESCRIPTION
Mongo 4 doesn't support anymore replica set protocol version 0.
This change explicitly sets version 1.

Also I added test setup scripts from CI, and removed the skip in tests.

Fixes #26 