### PR TITLE
Verify the outcome of a insert/update/delete command

### DIFF
--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/commandAndVerify..st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/commandAndVerify..st
@@ -1,0 +1,9 @@
+operations
+commandAndVerify: anOrderedDictionary
+	| res |
+	res := root command: anOrderedDictionary database: self.
+	res at: 'writeConcernError' ifPresent: [:err |
+		MongoCommandError signalFor: err].
+	res at: 'writeErrors' ifPresent: [:errors |
+		MongoCommandError signalFor: errors last].
+	^ res

--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/commandDelete.limit.collection.writeConcern..st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/commandDelete.limit.collection.writeConcern..st
@@ -13,4 +13,4 @@ commandDelete: origDictionary limit: aLimit collection: collectionName writeConc
 		} as: OrderedDictionary.
 	aConcern ifNotNil: [
 		dict at: 'writeConcern' put: aConcern concernForCommand].
-	^self command: dict.
+	^self commandAndVerify: dict.

--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/commandInsert.collection.writeConcern..st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/commandInsert.collection.writeConcern..st
@@ -10,4 +10,4 @@ commandInsert: newDictionary collection: collectionName writeConcern: aConcern
 		} as: OrderedDictionary.
 	aConcern ifNotNil: [
 		dict at: 'writeConcern' put: aConcern concernForCommand].
-	^self command: dict.
+	^self commandAndVerify: dict.

--- a/mc/Mongo-Core.package/MongoDatabase.class/instance/commandUpdate.with.collection.writeConcern..st
+++ b/mc/Mongo-Core.package/MongoDatabase.class/instance/commandUpdate.with.collection.writeConcern..st
@@ -13,4 +13,4 @@ commandUpdate: origDictionary with: newDictionary collection: collectionName wri
 		} as: OrderedDictionary.
 	aConcern ifNotNil: [
 		dict at: 'writeConcern' put: aConcern concernForCommand].
-	^self command: dict.
+	^self commandAndVerify: dict.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/setUp.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/setUp.st
@@ -1,0 +1,5 @@
+tests
+setUp
+	super setUp.
+	database := mongo databaseNamed: 'test'.
+	collection := database addCollection: 'testCollection'.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/tearDown.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/tearDown.st
@@ -1,0 +1,4 @@
+tests
+tearDown
+	collection drop.
+	super tearDown.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testInsertWithWriteConcern_error.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testInsertWithWriteConcern_error.st
@@ -1,0 +1,49 @@
+tests
+testInsertWithWriteConcern_error
+	| results concern |
+	"Inserts two documents and verifies that inserting the second document
+	violates a unique key constraint. Verify the document has not changed."
+	concern := MongoWriteConcern new
+		w: 1;
+		yourself.
+
+	"Create an index with a unique key constraint."
+	database
+		command:
+			({('createIndexes' -> collection name).
+			('indexes'
+				->
+					{({('key' -> {('user_id' -> 1)} asDictionary).
+					('unique' -> true).
+					('name' -> 'unique_user_id')} as: OrderedDictionary)})}
+				as: OrderedDictionary).
+	collection
+		commandInsert:
+			(Dictionary new
+				at: 'user_id' put: '1';
+				yourself)
+		writeConcern: concern.
+	results := collection query: [ :query |  ].
+	self assert: results size equals: 1.
+	self assert: (results first at: 'user_id') equals: '1'.
+
+	"Attempt to insert with a duplicate key"
+	self
+		should: [ collection
+				commandInsert:
+					(Dictionary new
+						at: 'user_id' put: '1';
+						at: 'other' put: 3;
+						yourself)
+				writeConcern: concern ]
+		raise: MongoCommandError
+		withExceptionDo: [ :ex | 
+			self assert: ex code equals: 11000.
+			self
+				assert: ex errorMessage
+				equals:
+					'E11000 duplicate key error collection: test.testCollection index: unique_user_id dup key: { : "1" }' ].
+
+	results := collection query: [ :query |  ].
+	self assert: results size equals: 1.
+	self deny: (results first includesKey: 'other')

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testRemoveWithWriteConcern_error.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testRemoveWithWriteConcern_error.st
@@ -1,0 +1,17 @@
+tests
+testRemoveWithWriteConcern_error
+	| data concern |
+	"Removes an entry from the collection with an impossible write concern and
+	verifies that an exception is raised. The document is still deleted from the
+	collection."
+	concern := MongoWriteConcern new w: 1000; yourself.
+	data := Dictionary new at: 'key' put: 'value'; yourself.
+	collection add: data.
+	self assert: collection size equals: 1.
+	self
+		should: [collection commandDelete: data limit: 1 writeConcern: concern]
+		raise: MongoCommandError
+		withExceptionDo: [:ex |
+			self assert: ex code equals: 100.
+			self assert: ex errorMessage equals: 'Not enough data-bearing nodes'].
+	self assert: collection isEmpty.

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testUpdateWithWriteConcern_error.st
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/instance/testUpdateWithWriteConcern_error.st
@@ -1,0 +1,20 @@
+tests
+testUpdateWithWriteConcern_error
+	| result old new concern |
+	"Attempts to update a document with an impossible write cocern. Verify that this
+	raises an exception (the actual effect on the collection will still happen)."
+	concern := MongoWriteConcern new
+		w: 1000;
+		yourself.
+	old := {('key' -> 'value')} asDictionary.
+	new := {('key' -> 'new value')} asDictionary.
+	collection add: old.
+	self
+		should: [ collection commandUpdate: old with: new writeConcern: concern ]
+		raise: MongoCommandError
+		withExceptionDo: [ :ex | 
+			self assert: ex code equals: 100.
+			self assert: ex errorMessage equals: 'Not enough data-bearing nodes' ].
+	result := collection query: [ :query |  ].
+	self assert: result size equals: 1.
+	self assert: (result first at: 'key') equals: 'new value'

--- a/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/properties.json
+++ b/mc/Mongo-Tests-Core.package/MongoReplicationOkTest.class/properties.json
@@ -5,7 +5,10 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [ ],
+	"instvars" : [
+		"database",
+		"collection"
+	],
 	"name" : "MongoReplicationOkTest",
 	"type" : "normal"
 }

--- a/mc/Mongo-Tests-Core.package/MongoTest.class/instance/testUpdateWithWriteConcern.st
+++ b/mc/Mongo-Tests-Core.package/MongoTest.class/instance/testUpdateWithWriteConcern.st
@@ -5,8 +5,7 @@ testUpdateWithWriteConcern
 	new := { 'key' -> 'new value' } asDictionary.
 
 	collection add: old.
-	collection commandUpdate: old with: new.
+	collection commandUpdate: old with: new writeConcern: self aWriteConcern.
 	result := collection query: [:query | ].
 	self assert: result size equals: 1.
 	self assert: (result first at: 'key') equals: 'new value'.
-


### PR DESCRIPTION
The commandInsert currently passes even if there is a unique key violation. Check the writeConcernError and the writeErrors. In case of multiple errors only raise an exception for the last one. This should match the behavior of getLastError.