### PR TITLE
Drop CI testing with mongodb v3.4 + add Pharo 8

### DIFF
--- a/.install_mongodb_on_travis.sh
+++ b/.install_mongodb_on_travis.sh
@@ -7,12 +7,7 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF50
 # version 4 key
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
 
-if [ "$MONGODB" = "3.4" ]; then
-    echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb.list
-    sudo apt-get update
-    sudo apt-get install mongodb-org-server=3.4.20 mongodb-org-shell=3.4.20
-    # service should be started automatically
-elif [ "$MONGODB" = "3.6" ]; then
+if [ "$MONGODB" = "3.6" ]; then
     echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb.list
     sudo apt-get update
     sudo apt-get install mongodb-org-server=3.6.12 mongodb-org-shell=3.6.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ os:
   - linux
 
 smalltalk:
+  - Pharo64-8.0
   - Pharo64-7.0
   - Pharo32-6.1
 
 env:
   - MONGODB=4.0
   - MONGODB=3.6
-  - MONGODB=3.4
 
 matrix:
   # Finish the build as soon as one job fails


### PR DESCRIPTION
Mongodb install script is already failing for that version and they will drop support next month.

https://www.ibm.com/cloud/blog/end-of-life-coming-to-mongodb-version-3-4-and-how-to-start-upgrading

Additionally, also test on Pharo 8, that is close to be released.