### PR TITLE
Conditional support for TLS

### DIFF
--- a/mc/Mongo-Core.package/Mongo.class/class/host.port..st
+++ b/mc/Mongo-Core.package/Mongo.class/class/host.port..st
@@ -1,5 +1,5 @@
 instance creation
 host: aString port: anInteger
 	"Return a new instance on the given server and port"
-	
-	^self new setHost: aString port: anInteger
+
+	^ self host: aString port: anInteger tls: false

--- a/mc/Mongo-Core.package/Mongo.class/class/host.port.tls..st
+++ b/mc/Mongo-Core.package/Mongo.class/class/host.port.tls..st
@@ -1,0 +1,5 @@
+instance creation
+host: aString port: anInteger tls: aBoolean
+	"Return a new instance on the given server and port"
+
+	^ self new setHost: aString port: anInteger tls: aBoolean

--- a/mc/Mongo-Core.package/Mongo.class/instance/openConnectionToHost.port.timeout..st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/openConnectionToHost.port.timeout..st
@@ -1,0 +1,12 @@
+operations
+openConnectionToHost: aString port: anInteger timeout: timeoutInSeconds
+	| result |
+	result := self socketStreamClass
+		openConnectionToHost: aString
+		port: anInteger
+		timeout: timeoutInSeconds.
+	self tls
+		ifTrue: [ result sslSession serverName: self host. result connect ]
+	ifFalse: [ result socket setOption: 'TCP_NODELAY' value: 1 ].
+	result binary.
+	^ result

--- a/mc/Mongo-Core.package/Mongo.class/instance/openWithTimeout..st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/openWithTimeout..st
@@ -3,7 +3,5 @@ openWithTimeout: aDuration
 	| addr |
 	"Waits the specified number of seconds to open the connection."
 	addr := NetNameResolver addressForName: host timeout: 20.
-	stream := SocketStream openConnectionToHost: addr port: port timeout: aDuration asSeconds.
-	stream socket setOption: 'TCP_NODELAY' value: 1.
-	stream binary.
+	stream := self openConnectionToHost: addr port: port timeout: aDuration asSeconds.
 	authCache := nil

--- a/mc/Mongo-Core.package/Mongo.class/instance/setHost.port..st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/setHost.port..st
@@ -1,6 +1,3 @@
 private
 setHost: aString port: anInteger
-	requestID := 0.
-	host := aString.
-	port := anInteger.
-	"validate?"
+	^ self setHost: aString port: anInteger tls: false

--- a/mc/Mongo-Core.package/Mongo.class/instance/setHost.port.tls..st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/setHost.port.tls..st
@@ -1,0 +1,7 @@
+private
+setHost: aString port: anInteger tls: aBoolean
+	requestID := 0.
+	host := aString.
+	port := anInteger.
+	tls := aBoolean
+	"validate?"

--- a/mc/Mongo-Core.package/Mongo.class/instance/socketStreamClass.st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/socketStreamClass.st
@@ -1,0 +1,5 @@
+operations
+socketStreamClass
+	^ self tls
+		ifTrue: [ ZdcSecureSocketStream ]
+		ifFalse: [ SocketStream ]

--- a/mc/Mongo-Core.package/Mongo.class/instance/tls.st
+++ b/mc/Mongo-Core.package/Mongo.class/instance/tls.st
@@ -1,0 +1,3 @@
+accessing
+tls
+	^ tls

--- a/mc/Mongo-Core.package/Mongo.class/properties.json
+++ b/mc/Mongo-Core.package/Mongo.class/properties.json
@@ -15,7 +15,8 @@
 		"stream",
 		"requestID",
 		"authMechanism",
-		"authCache"
+		"authCache",
+		"tls"
 	],
 	"name" : "Mongo",
 	"type" : "normal"


### PR DESCRIPTION
This PR is a trivial change to add an optional "tls" parameter to the Mongo class. If omitted, it behaves as before.
It set to *true*, the socket class is ZdcSecureSocketStream instead, and sets the server name to comply with SNI.

I've tested it with MongoDB Atlas.