### PR TITLE
Fix 106

### DIFF
--- a/mc/Mongo-BSON.package/LittleEndianStream.class/instance/encode..st
+++ b/mc/Mongo-BSON.package/LittleEndianStream.class/instance/encode..st
@@ -1,3 +1,3 @@
 writing
 encode: aString
-	^(GratuitousIncompatibilities encodeString: aString) asByteArray
+	^ ZnUTF8Encoder default encodeString: aString


### PR DESCRIPTION
Elide use of GratuitousIncompatibilites class as it refers to UTF8TextConverter (deprecated in P9, missing in P10)